### PR TITLE
Silently ignore COGs we don't know about!

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#CONCOCT 0.4.1 [![Build Status](https://travis-ci.org/BinPro/CONCOCT.png?branch=master)](https://travis-ci.org/BinPro/CONCOCT)#
+#CONCOCT 0.4.1 [![Build Status](https://travis-ci.org/BinPro/CONCOCT.png?branch=master)](https://travis-ci.org/BinPro/CONCOCT)
 
 A program for unsupervised binning of metagenomic contigs by using nucleotide composition, 
 coverage data in multiple samples and linkage data from paired end reads.
@@ -15,7 +15,7 @@ Johannes Alneberg, Brynjar Smári Bjarnason, Ino de Bruijn, Melanie Schirmer, Jo
 ## Documentation ##
 A comprehensive documentation for concoct is hosted on [readthedocs](https://concoct.readthedocs.org).
 
-##Support##
+## Support ##
 If you are having issues, please let us know. We have a mailing list located at: concoct-support@lists.sourcefourge.net which you can also subscribe to [here](https://lists.sourceforge.net/lists/listinfo/concoct-support).
 
 ## Contribute ##

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#CONCOCT 0.4.1 [![Build Status](https://travis-ci.org/BinPro/CONCOCT.png?branch=master)](https://travis-ci.org/BinPro/CONCOCT)
+## CONCOCT 0.4.1 [![Build Status](https://travis-ci.org/BinPro/CONCOCT.png?branch=master)](https://travis-ci.org/BinPro/CONCOCT)
 
 A program for unsupervised binning of metagenomic contigs by using nucleotide composition, 
 coverage data in multiple samples and linkage data from paired end reads.

--- a/scripts/COG_table.py
+++ b/scripts/COG_table.py
@@ -161,7 +161,10 @@ def main(args):
         seq_cov_above_threshold =  percent_seq_covered >= RPSBLAST_SCOVS_THRESHOLD
         
         if pident_above_threshold and seq_cov_above_threshold:
-            cog_accession = cogrecords[record_d['sseqid'].split('|')[2]]['Accession']
+            thisacc = record_d['sseqid'].split('|')[2]
+            cog_accession = 'unknown'
+            if thisacc in cogrecords:
+                cog_accession = cogrecords[thisacc]['Accession']
             if args.gfffile:
                 contig = featureid_locations[record_d['qseqid']]
             else:

--- a/scripts/ConfPlot.R
+++ b/scripts/ConfPlot.R
@@ -19,6 +19,7 @@ confFile <- opt$confile
 
 Conf <- read.csv(confFile,header=TRUE,row.names=1)
 Conf.t <- t(Conf)
+Conf.t <- Conf.t[rowSums(Conf.t) > 0,]
 ConfP <- Conf.t/rowSums(Conf.t)
 
 crp <- colorRampPalette(c("blue","red","orange","yellow"))(100)


### PR DESCRIPTION
This commit edits COG_table.py so that if there is a COG in the RPS Blast results that is not in the cdd to cog table we ignore it. It happens if someone is using a newer COG table than was used to build the cdd to cog table.