### PR TITLE
Fix dependency problems where python 2 might not be supported anymore

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,8 @@
 argparse>=1.2.1
-bcbio-gff>=0.4
-biopython>=1.63
+bcbio-gff>=0.4,<=0.6.4; python_version < '3.0'
+bcbio-gff>=0.4; python_version >= '3.0'
+biopython>=1.63,<=1.72; python_version < '3.0'
+biopython>=1.63; python_version >= '3.0'
 nose>=1.3.0
 numpy>=1.8.0
 pandas>=0.13.0


### PR DESCRIPTION
Tests were broken for python 2 due to updates of packages `biopython` and `bcbio-gff`.