### PR TITLE
Warning if single-threaded

### DIFF
--- a/bin/concoct
+++ b/bin/concoct
@@ -85,6 +85,8 @@ if __name__=="__main__":
     else:
         args.pca_components = args.total_percentage_pca/100.0
 
+    if args.threads == 1:
+        logging.warning("CONCOCT is running in single threaded mode. Please, consider adjusting the --threads parameter.")
     results = main(args)
 
-    print("CONCOCT Finished, the log shows how it went.", file=sys.stderr)
+    logging.info("CONCOCT Finished, the log shows how it went.")

--- a/concoct/output.py
+++ b/concoct/output.py
@@ -52,6 +52,11 @@ class Output(object):
             "PCA_components_data_gt{0}.csv"
         self.LOG_FILE_BASE = self.CONCOCT_PATH + 'log.txt'
 
+        # Reset any previous logging handlers, see:
+        # https://stackoverflow.com/a/49202811
+        for handler in logging.root.handlers[:]:
+            logging.root.removeHandler(handler)
+
         logging.basicConfig(
             filename=self.LOG_FILE_BASE,
             level=logging.INFO,


### PR DESCRIPTION
A warning will be printed if only one thread is used. Fixes #233.

Also included a small fix for why a log file was not created on some (my) setups.