### PR TITLE
fix use of deprecated API

### DIFF
--- a/scripts/concoct_coverage_table.py
+++ b/scripts/concoct_coverage_table.py
@@ -58,7 +58,7 @@ def generate_input_table(bedfile, bamfiles, samplenames=None):
             from io import StringIO
 
         fh = StringIO(out.decode('utf-8'))
-        df = pd.read_table(fh, header=None)
+        df = pd.read_csv(fh, header=None, sep='\t')
         avg_coverage_depth = df[df.columns[4:]].divide((df[2]-df[1]), axis=0)
         avg_coverage_depth.index = df[3]
         avg_coverage_depth.columns = header 


### PR DESCRIPTION
```
/ceph/mgx-sw/lib/python3.5/site-packages/concoct-1.1.0-py3.5-linux-x86_64.egg/EGG-INFO/scripts/concoct_coverage_table.py:61: FutureWarning: read_table is deprecated, use read_csv instead, passing sep='\t'.
```
