### PR TITLE
added 5th argument for vbgmm, using .values

### DIFF
--- a/bin/concoct_refine
+++ b/bin/concoct_refine
@@ -16,15 +16,15 @@ def main(args):
     
     original_data = p.read_csv(args.original_data, header=0, index_col=0)
     
-    original_data_matrix = original_data.to_numpy()
+    original_data_matrix = original_data.values
     
     scg_freq = p.read_csv(args.scg_file, header=0, index_col=0)
     
-    scg_freq_matrix = scg_freq.to_numpy()
+    scg_freq_matrix = scg_freq.values
     
     med_scgs = np.median(scg_freq_matrix, axis=1) 
     
-    clusters_matrix = clusters.to_numpy()
+    clusters_matrix = clusters.values
     
     cluster_freq = np.bincount(clusters_matrix[:,0]) 
     
@@ -45,7 +45,7 @@ def main(args):
             
             NK = med_scgs[k]*args.expansion_factor
             print("Run CONCOCT for " + str(k) + "with " + str(NK) + "clusters" + " using " + str(args.threads) + "threads")
-            assigns = vbgmm.fit(np.copy(transform_k,order='C'), int(NK), args.seed, args.threads)
+            assigns = vbgmm.fit(np.copy(transform_k,order='C'), int(NK), args.seed, args.threads, args.i)
             kK = np.max(assigns) + 1
             
             
@@ -75,6 +75,10 @@ if __name__ == "__main__":
 
     parser.add_argument('-t','--threads',default=1, type=int,
                         help=("number of threads to use defaults to one"))
+
+    parser.add_argument('-i','--iterations',type=int, default=500,
+      help=('Specify maximum number of iterations for the VBGMM. '
+            'Default value is 500'))
 
     args = parser.parse_args()
 


### PR DESCRIPTION
Hi Johannes

Somehow followup of issue #272, I changed all the deprecated call to as_matrix with the .values. I think the current deveop branch has .to_numpy() method, I tried that once and it did not work. 

I also chanced upon another issue, since last year vbgmm ask for a 5th argument, the number of iterations. I copied/paste the same flag/default as concoct for number of iterations and added it to vbgmm.fit .

Best,

Seb

