### PR TITLE
fix issue 171, to make script work with ambiguous bases by ignoring them

### DIFF
--- a/scripts/fasta_to_features.py
+++ b/scripts/fasta_to_features.py
@@ -37,7 +37,13 @@ def generate_features_from_fasta(fasta_file,nr_datapoints,kmer_len,outfile):
     for i,seq in enumerate(seqs):
         contigs_id.append(seq.id)
         for kmer_tuple in window(str(seq.seq).upper(),kmer_len):
-            contigs[i,kmer_dict["".join(kmer_tuple)]] += 1
+            try:
+                contigs[i,kmer_dict["".join(kmer_tuple)]] += 1
+            except KeyError:
+                # in case the kmer is not in the prepared
+                # dictionary, we skip it. This can be caused by
+                # ambigious bases such as N
+                continue
     df = pd.DataFrame(contigs,index=contigs_id)
     df.to_csv(outfile)
 #    print contigs_id


### PR DESCRIPTION
I suggest this fix to close issue https://github.com/BinPro/CONCOCT/issues/171
Instead of checking only for "N"s, this solution will skip any kmer that is not in the dictionary key. Thus making the script work with any ambiguous base.